### PR TITLE
Add missing algorithm include

### DIFF
--- a/lib/include/NPC.hpp
+++ b/lib/include/NPC.hpp
@@ -3,6 +3,7 @@
 #include "Board.hpp"
 
 #include <chrono>
+#include <algorithm>
 
 namespace ms_pacman {
 


### PR DESCRIPTION
Failed to build without it, due to missing std::upper_bound
Not entirely sure if it should be in NPC.hpp or GhostBase.hpp